### PR TITLE
fix: PostgreSQL 포트 번호 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
-
 services:
   db:
     image: postgres:15
     container_name: postgres
     ports:
-      - "5433:5432"
+      - "5432:5432"
     environment:
       POSTGRES_DB: database
       POSTGRES_USER: root


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**

- fix/#33 

👷 **작업한 내용**

<!-- 작업한 내용을 적어주세요. -->
- 서버와 db간 연결을 위해 변경

infisical에서 환경변수를 받아 서버와 DB가 연결되기 위해 포트 번호를 변경하였습니다.

## 📟 관련 이슈

- Resolved: #33 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 데이터베이스 서비스의 외부 포트 매핑이 5433에서 5432로 변경되었습니다. 서비스 동작은 변경되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->