### PR TITLE
[Feat] 제품 API 응답에 상품 상태와 판매자 닉네임을 노출 /#66

### DIFF
--- a/src/main/java/potato/backend/domain/product/domain/Condition.java
+++ b/src/main/java/potato/backend/domain/product/domain/Condition.java
@@ -1,0 +1,7 @@
+package potato.backend.domain.product.domain;
+
+public enum Condition {
+    NEW,
+    USED,
+    REFURBISHED
+}

--- a/src/main/java/potato/backend/domain/product/domain/Product.java
+++ b/src/main/java/potato/backend/domain/product/domain/Product.java
@@ -155,7 +155,8 @@ public class Product extends BaseEntity {
     }
 
     // == 비즈니스 메서드 ==
-    public void update(String title, String content, BigDecimal price, Status status, String mainImageUrl) {
+    public void update(String title, String content, BigDecimal price, Status status, String mainImageUrl,
+                       List<Category> categories, List<String> imageUrls) {
         if (title != null) {
             this.title = title;
         }
@@ -173,6 +174,21 @@ public class Product extends BaseEntity {
         }
         if (mainImageUrl != null) {
             this.mainImageUrl = mainImageUrl;
+        }
+        if (categories != null) {
+            this.categories.clear();
+            this.categories.addAll(categories);
+        }
+        if (imageUrls != null) {
+            this.images.clear();
+            List<Image> newImages = imageUrls.stream()
+                    .map(url -> {
+                        Image image = Image.create(url);
+                        image.setProduct(this);
+                        return image;
+                    })
+                    .toList();
+            this.images.addAll(newImages);
         }
     }
 

--- a/src/main/java/potato/backend/domain/product/domain/Product.java
+++ b/src/main/java/potato/backend/domain/product/domain/Product.java
@@ -63,6 +63,10 @@ public class Product extends BaseEntity {
     private Status status;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Condition condition;
+
+    @Column(nullable = false)
     @Builder.Default
     private Long viewCount = 0L;
 

--- a/src/main/java/potato/backend/domain/product/domain/Product.java
+++ b/src/main/java/potato/backend/domain/product/domain/Product.java
@@ -84,7 +84,8 @@ public class Product extends BaseEntity {
             List<String> imageUrls,
             BigDecimal price,
             Status status,
-            String mainImageUrl
+            String mainImageUrl,
+            Condition condition
     ) {
         Objects.requireNonNull(member, "member");
         Objects.requireNonNull(categories, "categories");
@@ -94,6 +95,7 @@ public class Product extends BaseEntity {
         Objects.requireNonNull(status, "status");
         Objects.requireNonNull(mainImageUrl, "mainImageUrl");
         Objects.requireNonNull(imageUrls, "imageUrls");
+        Objects.requireNonNull(condition, "condition");
 
         if (categories.isEmpty()) {
             throw new IllegalArgumentException("categories must not be empty");
@@ -118,6 +120,7 @@ public class Product extends BaseEntity {
                 .mainImageUrl(mainImageUrl)
                 .price(normalized)
                 .status(status)
+                .condition(condition)
                 .build();
 
         // 이미지 URL 문자열로부터 Image 엔티티 생성 및 추가

--- a/src/main/java/potato/backend/domain/product/domain/Status.java
+++ b/src/main/java/potato/backend/domain/product/domain/Status.java
@@ -2,5 +2,6 @@ package potato.backend.domain.product.domain;
 
 public enum Status {
     SELLING,
+    RESERVED,
     SOLD_OUT
 }

--- a/src/main/java/potato/backend/domain/product/dto/ProductCreateRequest.java
+++ b/src/main/java/potato/backend/domain/product/dto/ProductCreateRequest.java
@@ -34,6 +34,9 @@ public class ProductCreateRequest {
     @Schema(description = "판매 상태", example = "SELLING")
     private final String status;
 
+    @Schema(description = "상품 상태", example = "USED")
+    private final String condition;
+
     public static ProductCreateRequest of (
             Long memberId,
             String title,
@@ -42,7 +45,8 @@ public class ProductCreateRequest {
             String mainImageUrl,
             List<String> images,
             Long price,
-            String status
+            String status,
+            String condition
     ) {
         return new ProductCreateRequest(
                 memberId,
@@ -52,7 +56,8 @@ public class ProductCreateRequest {
                 mainImageUrl,
                 images,
                 price,
-                status
+                status,
+                condition
         );
     }
 }

--- a/src/main/java/potato/backend/domain/product/dto/ProductCreateRequest.java
+++ b/src/main/java/potato/backend/domain/product/dto/ProductCreateRequest.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+import potato.backend.domain.product.domain.Condition;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -34,8 +35,8 @@ public class ProductCreateRequest {
     @Schema(description = "판매 상태", example = "SELLING")
     private final String status;
 
-@Schema(description = "상품 상태", example = "USED")
-private final Condition condition;
+    @Schema(description = "상품 상태", example = "USED")
+    private final String condition;
 
     public static ProductCreateRequest of (
             Long memberId,

--- a/src/main/java/potato/backend/domain/product/dto/ProductCreateRequest.java
+++ b/src/main/java/potato/backend/domain/product/dto/ProductCreateRequest.java
@@ -34,8 +34,8 @@ public class ProductCreateRequest {
     @Schema(description = "판매 상태", example = "SELLING")
     private final String status;
 
-    @Schema(description = "상품 상태", example = "USED")
-    private final String condition;
+@Schema(description = "상품 상태", example = "USED")
+private final Condition condition;
 
     public static ProductCreateRequest of (
             Long memberId,

--- a/src/main/java/potato/backend/domain/product/dto/ProductListResponse.java
+++ b/src/main/java/potato/backend/domain/product/dto/ProductListResponse.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 @Getter
 public class ProductListResponse {
     private Long id;
+    private String nickname;
     private Long productId;
     private List<String> category;
     private String title;
@@ -25,6 +26,7 @@ public class ProductListResponse {
     public static ProductListResponse fromEntity(Product product) {
         ProductListResponse response = new ProductListResponse();
         response.id = product.getMember().getId();
+        response.nickname = product.getMember().getName();
         response.productId = product.getId();
         response.title = product.getTitle();
         response.category = product.getCategories()

--- a/src/main/java/potato/backend/domain/product/dto/ProductListResponse.java
+++ b/src/main/java/potato/backend/domain/product/dto/ProductListResponse.java
@@ -14,6 +14,7 @@ public class ProductListResponse {
     private String nickname;
     private Long productId;
     private List<String> category;
+    private String condition;
     private String title;
     private Long price;
     private String mainImageUrl;
@@ -33,6 +34,7 @@ public class ProductListResponse {
                 .stream()
                 .map(Category::getCategoryName)
                 .collect(Collectors.toList());
+        response.condition = product.getCondition().name();
         response.price = product.getPrice().longValue();
         response.mainImageUrl = product.getMainImageUrl();
         response.status = product.getStatus().name();

--- a/src/main/java/potato/backend/domain/product/dto/ProductResponse.java
+++ b/src/main/java/potato/backend/domain/product/dto/ProductResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Getter
 public class ProductResponse {
     private Long id;
+    private String nickname;
     private Long productId;
     private List<Category> categories;
     private String title;
@@ -26,6 +27,7 @@ public class ProductResponse {
     public static ProductResponse fromEntity(Product product) {
         ProductResponse response = new ProductResponse();
         response.id = product.getMember().getId();
+        response.nickname = product.getMember().getName();
         response.productId = product.getId();
         response.categories = product.getCategories();
         response.title = product.getTitle();

--- a/src/main/java/potato/backend/domain/product/dto/ProductResponse.java
+++ b/src/main/java/potato/backend/domain/product/dto/ProductResponse.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import potato.backend.domain.category.domain.Category;
 import potato.backend.domain.image.domain.Image;
 import potato.backend.domain.image.dto.ImageResponse;
+import potato.backend.domain.product.domain.Condition;
 import potato.backend.domain.product.domain.Product;
 
 import java.util.List;
@@ -15,7 +16,7 @@ public class ProductResponse {
     private Long productId;
     private List<Category> categories;
     private String title;
-    private String content;
+    private Condition content;
     private Long price;
     private List<ImageResponse> images;
     private String status;
@@ -31,7 +32,7 @@ public class ProductResponse {
         response.productId = product.getId();
         response.categories = product.getCategories();
         response.title = product.getTitle();
-        response.content = product.getContent();
+        response.content = product.getCondition();
         response.price = product.getPrice().longValue();
         response.images = ImageResponse.fromList(product.getImages());
         response.status = product.getStatus().name();

--- a/src/main/java/potato/backend/domain/product/dto/ProductUpdateRequest.java
+++ b/src/main/java/potato/backend/domain/product/dto/ProductUpdateRequest.java
@@ -7,7 +7,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.stereotype.Service;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)

--- a/src/main/java/potato/backend/domain/product/dto/ProductUpdateRequest.java
+++ b/src/main/java/potato/backend/domain/product/dto/ProductUpdateRequest.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.stereotype.Service;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -30,4 +31,7 @@ public class ProductUpdateRequest {
 
     @Schema(description = "판매 상태", example = "RESERVED")
     private final String status;
+
+    @Schema(description = "상품 상태", example = "USED")
+    private final String condition;
 }

--- a/src/main/java/potato/backend/domain/product/dto/ProductUpdateRequest.java
+++ b/src/main/java/potato/backend/domain/product/dto/ProductUpdateRequest.java
@@ -32,6 +32,6 @@ public class ProductUpdateRequest {
     @Schema(description = "판매 상태", example = "RESERVED")
     private final String status;
 
-    @Schema(description = "상품 상태", example = "USED")
-    private final String condition;
+@Schema(description = "상품 상태", example = "USED")
+private final String condition;
 }

--- a/src/main/java/potato/backend/domain/product/dto/ProductUpdateRequest.java
+++ b/src/main/java/potato/backend/domain/product/dto/ProductUpdateRequest.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProductUpdateRequest {
 
@@ -33,4 +33,7 @@ public class ProductUpdateRequest {
 
     @Schema(description = "상품 상태", example = "USED")
     private final String condition;
+
+    @Schema(description = "카테고리 목록", example = "[\"디지털\", \"가전\"]")
+    private final List<String> category;
 }

--- a/src/main/java/potato/backend/domain/product/dto/ProductUpdateRequest.java
+++ b/src/main/java/potato/backend/domain/product/dto/ProductUpdateRequest.java
@@ -31,6 +31,6 @@ public class ProductUpdateRequest {
     @Schema(description = "판매 상태", example = "RESERVED")
     private final String status;
 
-@Schema(description = "상품 상태", example = "USED")
-private final String condition;
+    @Schema(description = "상품 상태", example = "USED")
+    private final String condition;
 }

--- a/src/main/java/potato/backend/domain/product/service/ProductService.java
+++ b/src/main/java/potato/backend/domain/product/service/ProductService.java
@@ -14,6 +14,7 @@ import potato.backend.domain.category.domain.Category;
 import potato.backend.domain.category.repository.CategoryRepository;
 import potato.backend.domain.product.domain.Product;
 import potato.backend.domain.product.domain.Status;
+import potato.backend.domain.product.domain.Condition;
 import potato.backend.domain.product.dto.ProductCreateRequest;
 import potato.backend.domain.product.dto.ProductListResponse;
 import potato.backend.domain.product.dto.ProductResponse;
@@ -99,7 +100,8 @@ public class ProductService {
                 request.getImages(),
                 BigDecimal.valueOf(request.getPrice()),
                 Status.valueOf(request.getStatus()),
-                request.getMainImageUrl()
+                request.getMainImageUrl(),
+                Condition.valueOf(request.getCondition())
         );
 
         Product savedProduct = productRepository.save(product);

--- a/src/main/java/potato/backend/domain/product/service/ProductService.java
+++ b/src/main/java/potato/backend/domain/product/service/ProductService.java
@@ -140,10 +140,50 @@ public class ProductService {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new ProductNotFoundException(productId));
 
+        // 카테고리 처리
+        List<Category> categories = null;
+        if (request.getCategory() != null) {
+            // 입력된 카테고리명 정규화
+            List<String> requestedCategoryNames = request.getCategory().stream()
+                    .filter(name -> name != null)
+                    .map(String::trim)
+                    .filter(name -> !name.isEmpty())
+                    .distinct()
+                    .toList();
+
+            if (!requestedCategoryNames.isEmpty()) {
+                // 1) 이미 존재하는 카테고리 조회
+                List<Category> existingCategories = categoryRepository.findByNameIn(requestedCategoryNames);
+
+                // 2) 없는 이름은 새로 생성
+                java.util.Set<String> existingNames = existingCategories.stream()
+                        .map(Category::getCategoryName)
+                        .collect(java.util.stream.Collectors.toSet());
+
+                List<String> missingNames = requestedCategoryNames.stream()
+                        .filter(name -> !existingNames.contains(name))
+                        .toList();
+
+                List<Category> newCategories = missingNames.stream()
+                        .map(potato.backend.domain.category.domain.Category::create)
+                        .toList();
+
+                if (!newCategories.isEmpty()) {
+                    newCategories = categoryRepository.saveAll(newCategories);
+                }
+
+                // 3) 최종 카테고리 목록 결합
+                categories = new java.util.ArrayList<>(existingCategories);
+                categories.addAll(newCategories);
+            }
+        }
+
         product.update(request.getTitle(), request.getContent(),
-                BigDecimal.valueOf(request.getPrice()),
-                Status.valueOf(request.getStatus()),
-                request.getMainImageUrl());
+                request.getPrice() != null ? BigDecimal.valueOf(request.getPrice()) : null,
+                request.getStatus() != null ? Status.valueOf(request.getStatus()) : null,
+                request.getMainImageUrl(),
+                categories,
+                request.getImageUrls());
 
         log.info("상품 수정 완료 - productId: {}", productId);
         return ProductResponse.fromEntity(product);

--- a/src/test/java/potato/backend/domain/image/ImageDomainTest.java
+++ b/src/test/java/potato/backend/domain/image/ImageDomainTest.java
@@ -12,6 +12,7 @@ import potato.backend.domain.category.domain.Category;
 import potato.backend.domain.image.domain.Image;
 import potato.backend.domain.product.domain.Product;
 import potato.backend.domain.product.domain.Status;
+import potato.backend.domain.product.domain.Condition;
 import potato.backend.domain.storage.service.S3Service;
 import potato.backend.domain.user.domain.Member;
 
@@ -81,8 +82,7 @@ class ImageDomainTest {
                 "images/test-image-3.png",
                 "images/test-image-4.png",
                 "images/test-image-5.png",
-                "images/test-image-6.png"
-        );
+                "images/test-image-6.png");
 
         // when & then
         testImages.forEach(imageUrl -> {
@@ -180,11 +180,9 @@ class ImageDomainTest {
             s3Service.deleteFiles(uploadedUrls);
 
             // 모두 삭제되었는지 확인
-            uploadedUrls.forEach(url ->
-                    assertThat(s3Service.fileExists(url))
-                            .as("삭제된 이미지가 S3에 존재하지 않아야 합니다: %s", url)
-                            .isFalse()
-            );
+            uploadedUrls.forEach(url -> assertThat(s3Service.fileExists(url))
+                    .as("삭제된 이미지가 S3에 존재하지 않아야 합니다: %s", url)
+                    .isFalse());
 
             System.out.println("✅ 모든 파일 삭제 및 검증 완료");
         }
@@ -202,8 +200,7 @@ class ImageDomainTest {
             List<MultipartFile> imageFiles = List.of(
                     createMockMultipartFile("test-image-2.png"),
                     createMockMultipartFile("test-image-3.png"),
-                    createMockMultipartFile("test-image-4.png")
-            );
+                    createMockMultipartFile("test-image-4.png"));
 
             List<String> uploadedUrls = s3Service.uploadFiles(imageFiles);
 
@@ -221,8 +218,8 @@ class ImageDomainTest {
                     uploadedUrls,
                     BigDecimal.valueOf(100000),
                     Status.SELLING,
-                    uploadedUrls.get(0)
-            );
+                    uploadedUrls.get(0),
+                    Condition.NEW);
 
             // then - Product의 이미지가 올바르게 설정되었는지 확인
             assertThat(product.getImages()).hasSize(3);
@@ -264,8 +261,7 @@ class ImageDomainTest {
                     "file",
                     filename,
                     "image/png",
-                    content
-            );
+                    content);
         }
     }
 }

--- a/src/test/java/potato/backend/domain/image/ImageRepositoryTest.java
+++ b/src/test/java/potato/backend/domain/image/ImageRepositoryTest.java
@@ -12,6 +12,7 @@ import potato.backend.domain.image.domain.Image;
 import potato.backend.domain.image.repository.ImageRepository;
 import potato.backend.domain.product.domain.Product;
 import potato.backend.domain.product.domain.Status;
+import potato.backend.domain.product.domain.Condition;
 import potato.backend.domain.product.repository.ProductRepository;
 import potato.backend.domain.user.domain.Member;
 import potato.backend.domain.user.repository.MemberRepository;
@@ -71,8 +72,8 @@ class ImageRepositoryTest {
                 List.of(testImagePath1, testImagePath2),
                 BigDecimal.valueOf(100000),
                 Status.SELLING,
-                testImagePath1
-        );
+                testImagePath1,
+                Condition.NEW);
         productRepository.save(testProduct);
     }
 
@@ -154,8 +155,7 @@ class ImageRepositoryTest {
         List<Image> images = List.of(
                 Image.create(bulkImage1),
                 Image.create(bulkImage2),
-                Image.create(bulkImage3)
-        );
+                Image.create(bulkImage3));
 
         // when
         List<Image> savedImages = imageRepository.saveAll(images);

--- a/src/test/java/potato/backend/domain/product/ProductDomainTest.java
+++ b/src/test/java/potato/backend/domain/product/ProductDomainTest.java
@@ -6,6 +6,7 @@ import potato.backend.domain.category.domain.Category;
 import potato.backend.domain.image.domain.Image;
 import potato.backend.domain.product.domain.Product;
 import potato.backend.domain.product.domain.Status;
+import potato.backend.domain.product.domain.Condition;
 import potato.backend.domain.user.domain.Member;
 
 import java.math.BigDecimal;
@@ -17,227 +18,227 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @DisplayName("Product 도메인 테스트")
 class ProductDomainTest {
 
-    @Test
-    @DisplayName("상품 생성 성공 테스트")
-    void createProduct() {
-        // given
-        Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
-        Category category = Category.create("전자기기");
-        List<String> imageUrls = List.of("image1.jpg", "image2.jpg");
+        @Test
+        @DisplayName("상품 생성 성공 테스트")
+        void createProduct() {
+                // given
+                Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
+                Category category = Category.create("전자기기");
+                List<String> imageUrls = List.of("image1.jpg", "image2.jpg");
 
-        // when
-        Product product = Product.create(
-                member,
-                List.of(category),
-                "아이폰 15",
-                "새 제품입니다",
-                imageUrls,
-                BigDecimal.valueOf(1500000),
-                Status.SELLING,
-                "main.jpg"
-        );
+                // when
+                Product product = Product.create(
+                                member,
+                                List.of(category),
+                                "아이폰 15",
+                                "새 제품입니다",
+                                imageUrls,
+                                BigDecimal.valueOf(1500000),
+                                Status.SELLING,
+                                "main.jpg",
+                                Condition.NEW);
 
-        // then
-        assertThat(product).isNotNull();
-        assertThat(product.getTitle()).isEqualTo("아이폰 15");
-        assertThat(product.getContent()).isEqualTo("새 제품입니다");
-        assertThat(product.getPrice()).isEqualTo(BigDecimal.valueOf(1500000));
-        assertThat(product.getStatus()).isEqualTo(Status.SELLING);
-        assertThat(product.getMainImageUrl()).isEqualTo("main.jpg");
-        assertThat(product.getImages()).hasSize(2);
-        assertThat(product.getCategories()).hasSize(1);
-        assertThat(product.getMember()).isEqualTo(member);
-    }
+                // then
+                assertThat(product).isNotNull();
+                assertThat(product.getTitle()).isEqualTo("아이폰 15");
+                assertThat(product.getContent()).isEqualTo("새 제품입니다");
+                assertThat(product.getPrice()).isEqualTo(BigDecimal.valueOf(1500000));
+                assertThat(product.getStatus()).isEqualTo(Status.SELLING);
+                assertThat(product.getMainImageUrl()).isEqualTo("main.jpg");
+                assertThat(product.getImages()).hasSize(2);
+                assertThat(product.getCategories()).hasSize(1);
+                assertThat(product.getMember()).isEqualTo(member);
+        }
 
-    @Test
-    @DisplayName("상품 생성 시 member가 null이면 예외 발생")
-    void createProductWithNullMember() {
-        // given
-        Category category = Category.create("전자기기");
+        @Test
+        @DisplayName("상품 생성 시 member가 null이면 예외 발생")
+        void createProductWithNullMember() {
+                // given
+                Category category = Category.create("전자기기");
 
-        // when & then
-        assertThatThrownBy(() -> Product.create(
-                null,
-                List.of(category),
-                "아이폰 15",
-                "새 제품입니다",
-                List.of("image1.jpg"),
-                BigDecimal.valueOf(1500000),
-                Status.SELLING,
-                "main.jpg"
-        )).isInstanceOf(NullPointerException.class)
-          .hasMessageContaining("member");
-    }
+                // when & then
+                assertThatThrownBy(() -> Product.create(
+                                null,
+                                List.of(category),
+                                "아이폰 15",
+                                "새 제품입니다",
+                                List.of("image1.jpg"),
+                                BigDecimal.valueOf(1500000),
+                                Status.SELLING,
+                                "main.jpg",
+                                Condition.NEW)).isInstanceOf(NullPointerException.class)
+                                .hasMessageContaining("member");
+        }
 
-    @Test
-    @DisplayName("상품 생성 시 가격이 음수면 예외 발생")
-    void createProductWithNegativePrice() {
-        // given
-        Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
-        Category category = Category.create("전자기기");
+        @Test
+        @DisplayName("상품 생성 시 가격이 음수면 예외 발생")
+        void createProductWithNegativePrice() {
+                // given
+                Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
+                Category category = Category.create("전자기기");
 
-        // when & then
-        assertThatThrownBy(() -> Product.create(
-                member,
-                List.of(category),
-                "아이폰 15",
-                "새 제품입니다",
-                List.of("image1.jpg"),
-                BigDecimal.valueOf(-1000),
-                Status.SELLING,
-                "main.jpg"
-        )).isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("price must be >= 0");
-    }
+                // when & then
+                assertThatThrownBy(() -> Product.create(
+                                member,
+                                List.of(category),
+                                "아이폰 15",
+                                "새 제품입니다",
+                                List.of("image1.jpg"),
+                                BigDecimal.valueOf(-1000),
+                                Status.SELLING,
+                                "main.jpg",
+                                Condition.NEW)).isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("price must be >= 0");
+        }
 
-    @Test
-    @DisplayName("상품 생성 시 이미지가 비어있으면 예외 발생")
-    void createProductWithEmptyImages() {
-        // given
-        Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
-        Category category = Category.create("전자기기");
+        @Test
+        @DisplayName("상품 생성 시 이미지가 비어있으면 예외 발생")
+        void createProductWithEmptyImages() {
+                // given
+                Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
+                Category category = Category.create("전자기기");
 
-        // when & then
-        assertThatThrownBy(() -> Product.create(
-                member,
-                List.of(category),
-                "아이폰 15",
-                "새 제품입니다",
-                List.of(),
-                BigDecimal.valueOf(1500000),
-                Status.SELLING,
-                "main.jpg"
-        )).isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("imageUrls must not be empty");
-    }
+                // when & then
+                assertThatThrownBy(() -> Product.create(
+                                member,
+                                List.of(category),
+                                "아이폰 15",
+                                "새 제품입니다",
+                                List.of(),
+                                BigDecimal.valueOf(1500000),
+                                Status.SELLING,
+                                "main.jpg",
+                                Condition.NEW)).isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("imageUrls must not be empty");
+        }
 
-    @Test
-    @DisplayName("상품 정보 업데이트 테스트")
-    void updateProduct() {
-        // given
-        Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
-        Category category = Category.create("전자기기");
+        @Test
+        @DisplayName("상품 정보 업데이트 테스트")
+        void updateProduct() {
+                // given
+                Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
+                Category category = Category.create("전자기기");
 
-        Product product = Product.create(
-                member,
-                List.of(category),
-                "원래 제목",
-                "원래 내용",
-                List.of("image1.jpg"),
-                BigDecimal.valueOf(100000),
-                Status.SELLING,
-                "original.jpg"
-        );
+                Product product = Product.create(
+                                member,
+                                List.of(category),
+                                "원래 제목",
+                                "원래 내용",
+                                List.of("image1.jpg"),
+                                BigDecimal.valueOf(100000),
+                                Status.SELLING,
+                                "original.jpg",
+                                Condition.NEW);
 
-        // when
-        product.update("수정된 제목", "수정된 내용", BigDecimal.valueOf(150000), Status.SOLD_OUT, "updated.jpg");
+                // when
+                product.update("수정된 제목", "수정된 내용", BigDecimal.valueOf(150000), Status.SOLD_OUT, "updated.jpg", null,
+                                null);
 
-        // then
-        assertThat(product.getTitle()).isEqualTo("수정된 제목");
-        assertThat(product.getContent()).isEqualTo("수정된 내용");
-        assertThat(product.getPrice()).isEqualTo(BigDecimal.valueOf(150000));
-        assertThat(product.getStatus()).isEqualTo(Status.SOLD_OUT);
-        assertThat(product.getMainImageUrl()).isEqualTo("updated.jpg");
-    }
+                // then
+                assertThat(product.getTitle()).isEqualTo("수정된 제목");
+                assertThat(product.getContent()).isEqualTo("수정된 내용");
+                assertThat(product.getPrice()).isEqualTo(BigDecimal.valueOf(150000));
+                assertThat(product.getStatus()).isEqualTo(Status.SOLD_OUT);
+                assertThat(product.getMainImageUrl()).isEqualTo("updated.jpg");
+        }
 
-    @Test
-    @DisplayName("상품 부분 업데이트 테스트 - null 값은 업데이트하지 않음")
-    void updateProductPartially() {
-        // given
-        Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
-        Category category = Category.create("전자기기");
+        @Test
+        @DisplayName("상품 부분 업데이트 테스트 - null 값은 업데이트하지 않음")
+        void updateProductPartially() {
+                // given
+                Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
+                Category category = Category.create("전자기기");
 
-        Product product = Product.create(
-                member,
-                List.of(category),
-                "원래 제목",
-                "원래 내용",
-                List.of("image1.jpg"),
-                BigDecimal.valueOf(100000),
-                Status.SELLING,
-                "original.jpg"
-        );
+                Product product = Product.create(
+                                member,
+                                List.of(category),
+                                "원래 제목",
+                                "원래 내용",
+                                List.of("image1.jpg"),
+                                BigDecimal.valueOf(100000),
+                                Status.SELLING,
+                                "original.jpg",
+                                Condition.NEW);
 
-        // when - 제목만 업데이트
-        product.update("수정된 제목만", null, null, null, null);
+                // when - 제목만 업데이트
+                product.update("수정된 제목만", null, null, null, null, null, null);
 
-        // then
-        assertThat(product.getTitle()).isEqualTo("수정된 제목만");
-        assertThat(product.getContent()).isEqualTo("원래 내용");
-        assertThat(product.getPrice()).isEqualTo(BigDecimal.valueOf(100000));
-        assertThat(product.getStatus()).isEqualTo(Status.SELLING);
-        assertThat(product.getMainImageUrl()).isEqualTo("original.jpg");
-    }
+                // then
+                assertThat(product.getTitle()).isEqualTo("수정된 제목만");
+                assertThat(product.getContent()).isEqualTo("원래 내용");
+                assertThat(product.getPrice()).isEqualTo(BigDecimal.valueOf(100000));
+                assertThat(product.getStatus()).isEqualTo(Status.SELLING);
+                assertThat(product.getMainImageUrl()).isEqualTo("original.jpg");
+        }
 
-    @Test
-    @DisplayName("상품 업데이트 시 음수 가격이면 예외 발생")
-    void updateProductWithNegativePrice() {
-        // given
-        Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
-        Category category = Category.create("전자기기");
+        @Test
+        @DisplayName("상품 업데이트 시 음수 가격이면 예외 발생")
+        void updateProductWithNegativePrice() {
+                // given
+                Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
+                Category category = Category.create("전자기기");
 
-        Product product = Product.create(
-                member,
-                List.of(category),
-                "원래 제목",
-                "원래 내용",
-                List.of("image1.jpg"),
-                BigDecimal.valueOf(100000),
-                Status.SELLING,
-                "original.jpg"
-        );
+                Product product = Product.create(
+                                member,
+                                List.of(category),
+                                "원래 제목",
+                                "원래 내용",
+                                List.of("image1.jpg"),
+                                BigDecimal.valueOf(100000),
+                                Status.SELLING,
+                                "original.jpg",
+                                Condition.NEW);
 
-        // when & then
-        assertThatThrownBy(() -> product.update(null, null, BigDecimal.valueOf(-5000), null, null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("price must be >= 0");
-    }
+                // when & then
+                assertThatThrownBy(() -> product.update(null, null, BigDecimal.valueOf(-5000), null, null, null, null))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("price must be >= 0");
+        }
 
-    @Test
-    @DisplayName("가격 반올림 테스트")
-    void priceRounding() {
-        // given
-        Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
-        Category category = Category.create("전자기기");
+        @Test
+        @DisplayName("가격 반올림 테스트")
+        void priceRounding() {
+                // given
+                Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
+                Category category = Category.create("전자기기");
 
-        // when
-        Product product = Product.create(
-                member,
-                List.of(category),
-                "테스트 상품",
-                "가격 반올림 테스트",
-                List.of("image1.jpg"),
-                new BigDecimal("1234.56"),
-                Status.SELLING,
-                "main.jpg"
-        );
+                // when
+                Product product = Product.create(
+                                member,
+                                List.of(category),
+                                "테스트 상품",
+                                "가격 반올림 테스트",
+                                List.of("image1.jpg"),
+                                new BigDecimal("1234.56"),
+                                Status.SELLING,
+                                "main.jpg",
+                                Condition.NEW);
 
-        // then
-        assertThat(product.getPrice()).isEqualTo(new BigDecimal("1235"));
-    }
+                // then
+                assertThat(product.getPrice()).isEqualTo(new BigDecimal("1235"));
+        }
 
-    @Test
-    @DisplayName("상품 초기 조회수와 좋아요 수는 0이어야 함")
-    void initialCountsShouldBeZero() {
-        // given
-        Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
-        Category category = Category.create("전자기기");
+        @Test
+        @DisplayName("상품 초기 조회수와 좋아요 수는 0이어야 함")
+        void initialCountsShouldBeZero() {
+                // given
+                Member member = Member.create("테스트유저", "test@example.com", "password", "010-1234-5678");
+                Category category = Category.create("전자기기");
 
-        // when
-        Product product = Product.create(
-                member,
-                List.of(category),
-                "테스트 상품",
-                "초기 카운트 테스트",
-                List.of("image1.jpg"),
-                BigDecimal.valueOf(50000),
-                Status.SELLING,
-                "main.jpg"
-        );
+                // when
+                Product product = Product.create(
+                                member,
+                                List.of(category),
+                                "테스트 상품",
+                                "초기 카운트 테스트",
+                                List.of("image1.jpg"),
+                                BigDecimal.valueOf(50000),
+                                Status.SELLING,
+                                "main.jpg",
+                                Condition.NEW);
 
-        // then
-        assertThat(product.getViewCount()).isEqualTo(0L);
-        assertThat(product.getLikeCount()).isEqualTo(0L);
-    }
+                // then
+                assertThat(product.getViewCount()).isEqualTo(0L);
+                assertThat(product.getLikeCount()).isEqualTo(0L);
+        }
 }
-

--- a/src/test/java/potato/backend/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/potato/backend/domain/product/ProductRepositoryTest.java
@@ -13,6 +13,7 @@ import potato.backend.domain.category.repository.CategoryRepository;
 import potato.backend.domain.image.domain.Image;
 import potato.backend.domain.product.domain.Product;
 import potato.backend.domain.product.domain.Status;
+import potato.backend.domain.product.domain.Condition;
 import potato.backend.domain.product.repository.ProductRepository;
 import potato.backend.domain.user.domain.Member;
 import potato.backend.domain.user.repository.MemberRepository;
@@ -64,8 +65,8 @@ class ProductRepositoryTest {
                 imageUrls,
                 BigDecimal.valueOf(1500000),
                 Status.SELLING,
-                "main-image.jpg"
-        );
+                "main-image.jpg",
+                Condition.NEW);
 
         // when
         Product savedProduct = productRepository.save(product);
@@ -91,8 +92,8 @@ class ProductRepositoryTest {
                 List.of("image1.jpg"),
                 BigDecimal.valueOf(2500000),
                 Status.SELLING,
-                "macbook.jpg"
-        );
+                "macbook.jpg",
+                Condition.NEW);
         Product savedProduct = productRepository.save(product);
 
         // when
@@ -116,8 +117,8 @@ class ProductRepositoryTest {
                     List.of("image" + i + ".jpg"),
                     BigDecimal.valueOf(10000 * i),
                     Status.SELLING,
-                    "main" + i + ".jpg"
-            );
+                    "main" + i + ".jpg",
+                    Condition.NEW);
             productRepository.save(product);
         }
 
@@ -143,12 +144,13 @@ class ProductRepositoryTest {
                 List.of("image1.jpg"),
                 BigDecimal.valueOf(100000),
                 Status.SELLING,
-                "original.jpg"
-        );
+                "original.jpg",
+                Condition.NEW);
         Product savedProduct = productRepository.save(product);
 
         // when
-        savedProduct.update("수정된 제목", "수정된 내용", BigDecimal.valueOf(150000), Status.SOLD_OUT, "updated.jpg");
+        savedProduct.update("수정된 제목", "수정된 내용", BigDecimal.valueOf(150000), Status.SOLD_OUT, "updated.jpg",
+                List.of(testCategory), null);
         productRepository.save(savedProduct);
 
         // then
@@ -172,8 +174,8 @@ class ProductRepositoryTest {
                 List.of("image1.jpg"),
                 BigDecimal.valueOf(50000),
                 Status.SELLING,
-                "delete.jpg"
-        );
+                "delete.jpg",
+                Condition.NEW);
         Product savedProduct = productRepository.save(product);
         Long productId = savedProduct.getId();
 
@@ -197,8 +199,8 @@ class ProductRepositoryTest {
                 List.of("image1.jpg"),
                 BigDecimal.valueOf(30000),
                 Status.SELLING,
-                "exists.jpg"
-        );
+                "exists.jpg",
+                Condition.NEW);
         Product savedProduct = productRepository.save(product);
 
         // when & then
@@ -219,8 +221,8 @@ class ProductRepositoryTest {
                     List.of("image" + i + ".jpg"),
                     BigDecimal.valueOf(10000 * i),
                     Status.SELLING,
-                    "main" + i + ".jpg"
-            );
+                    "main" + i + ".jpg",
+                    Condition.NEW);
             productRepository.save(product);
         }
 
@@ -244,8 +246,8 @@ class ProductRepositoryTest {
                         List.of("image1.jpg"),
                         BigDecimal.valueOf(10000),
                         Status.SELLING,
-                        "main1.jpg"
-                ),
+                        "main1.jpg",
+                        Condition.NEW),
                 Product.create(
                         testMember,
                         List.of(testCategory),
@@ -254,8 +256,8 @@ class ProductRepositoryTest {
                         List.of("image2.jpg"),
                         BigDecimal.valueOf(20000),
                         Status.SELLING,
-                        "main2.jpg"
-                ),
+                        "main2.jpg",
+                        Condition.NEW),
                 Product.create(
                         testMember,
                         List.of(testCategory),
@@ -264,9 +266,8 @@ class ProductRepositoryTest {
                         List.of("image3.jpg"),
                         BigDecimal.valueOf(30000),
                         Status.SELLING,
-                        "main3.jpg"
-                )
-        );
+                        "main3.jpg",
+                        Condition.NEW));
 
         // when
         List<Product> savedProducts = productRepository.saveAll(products);
@@ -280,9 +281,12 @@ class ProductRepositoryTest {
     @DisplayName("제목으로 상품 검색 테스트")
     void searchByTitle() {
         // given
-        Product product1 = Product.create(testMember, List.of(testCategory), "아이폰 15", "설명1", List.of("image1.jpg"), BigDecimal.valueOf(1000000), Status.SELLING, "main1.jpg");
-        Product product2 = Product.create(testMember, List.of(testCategory), "아이폰 14", "설명2", List.of("image2.jpg"), BigDecimal.valueOf(900000), Status.SELLING, "main2.jpg");
-        Product product3 = Product.create(testMember, List.of(testCategory), "갤럭시 S24", "설명3", List.of("image3.jpg"), BigDecimal.valueOf(1100000), Status.SELLING, "main3.jpg");
+        Product product1 = Product.create(testMember, List.of(testCategory), "아이폰 15", "설명1", List.of("image1.jpg"),
+                BigDecimal.valueOf(1000000), Status.SELLING, "main1.jpg", Condition.NEW);
+        Product product2 = Product.create(testMember, List.of(testCategory), "아이폰 14", "설명2", List.of("image2.jpg"),
+                BigDecimal.valueOf(900000), Status.SELLING, "main2.jpg", Condition.NEW);
+        Product product3 = Product.create(testMember, List.of(testCategory), "갤럭시 S24", "설명3", List.of("image3.jpg"),
+                BigDecimal.valueOf(1100000), Status.SELLING, "main3.jpg", Condition.NEW);
 
         productRepository.saveAll(List.of(product1, product2, product3));
 
@@ -300,9 +304,12 @@ class ProductRepositoryTest {
     @DisplayName("상태별 상품 조회 테스트")
     void findByStatus() {
         // given
-        Product product1 = Product.create(testMember, List.of(testCategory), "판매중 상품1", "설명1", List.of("image1.jpg"), BigDecimal.valueOf(10000), Status.SELLING, "main1.jpg");
-        Product product2 = Product.create(testMember, List.of(testCategory), "판매중 상품2", "설명2", List.of("image2.jpg"), BigDecimal.valueOf(20000), Status.SELLING, "main2.jpg");
-        Product product3 = Product.create(testMember, List.of(testCategory), "품절 상품", "설명3", List.of("image3.jpg"), BigDecimal.valueOf(30000), Status.SOLD_OUT, "main3.jpg");
+        Product product1 = Product.create(testMember, List.of(testCategory), "판매중 상품1", "설명1", List.of("image1.jpg"),
+                BigDecimal.valueOf(10000), Status.SELLING, "main1.jpg", Condition.NEW);
+        Product product2 = Product.create(testMember, List.of(testCategory), "판매중 상품2", "설명2", List.of("image2.jpg"),
+                BigDecimal.valueOf(20000), Status.SELLING, "main2.jpg", Condition.NEW);
+        Product product3 = Product.create(testMember, List.of(testCategory), "품절 상품", "설명3", List.of("image3.jpg"),
+                BigDecimal.valueOf(30000), Status.SOLD_OUT, "main3.jpg", Condition.NEW);
 
         productRepository.saveAll(List.of(product1, product2, product3));
 
@@ -329,8 +336,8 @@ class ProductRepositoryTest {
                     List.of("image" + i + ".jpg"),
                     BigDecimal.valueOf(10000 * i),
                     Status.SELLING,
-                    "main" + i + ".jpg"
-            );
+                    "main" + i + ".jpg",
+                    Condition.NEW);
             productRepository.save(product);
         }
 
@@ -339,15 +346,13 @@ class ProductRepositoryTest {
         Page<Product> priceRangeProducts = productRepository.findByPriceRange(
                 BigDecimal.valueOf(20000),
                 BigDecimal.valueOf(40000),
-                pageable
-        );
+                pageable);
 
         // then
         assertThat(priceRangeProducts.getContent()).hasSize(3);
         assertThat(priceRangeProducts.getContent()).allMatch(
                 p -> p.getPrice().compareTo(BigDecimal.valueOf(20000)) >= 0
-                        && p.getPrice().compareTo(BigDecimal.valueOf(40000)) <= 0
-        );
+                        && p.getPrice().compareTo(BigDecimal.valueOf(40000)) <= 0);
     }
 
     @Test
@@ -357,9 +362,12 @@ class ProductRepositoryTest {
         Member anotherMember = Member.create("다른유저", "another@example.com", "hashedPassword", "010-9876-5432");
         memberRepository.save(anotherMember);
 
-        Product product1 = Product.create(testMember, List.of(testCategory), "테스트유저 상품1", "설명1", List.of("image1.jpg"), BigDecimal.valueOf(10000), Status.SELLING, "main1.jpg");
-        Product product2 = Product.create(testMember, List.of(testCategory), "테스트유저 상품2", "설명2", List.of("image2.jpg"), BigDecimal.valueOf(20000), Status.SELLING, "main2.jpg");
-        Product product3 = Product.create(anotherMember, List.of(testCategory), "다른유저 상품", "설명3", List.of("image3.jpg"), BigDecimal.valueOf(30000), Status.SELLING, "main3.jpg");
+        Product product1 = Product.create(testMember, List.of(testCategory), "테스트유저 상품1", "설명1", List.of("image1.jpg"),
+                BigDecimal.valueOf(10000), Status.SELLING, "main1.jpg", Condition.NEW);
+        Product product2 = Product.create(testMember, List.of(testCategory), "테스트유저 상품2", "설명2", List.of("image2.jpg"),
+                BigDecimal.valueOf(20000), Status.SELLING, "main2.jpg", Condition.NEW);
+        Product product3 = Product.create(anotherMember, List.of(testCategory), "다른유저 상품", "설명3", List.of("image3.jpg"),
+                BigDecimal.valueOf(30000), Status.SELLING, "main3.jpg", Condition.NEW);
 
         productRepository.saveAll(List.of(product1, product2, product3));
 
@@ -370,8 +378,7 @@ class ProductRepositoryTest {
         // then
         assertThat(testMemberProducts.getContent()).hasSize(2);
         assertThat(testMemberProducts.getContent()).allMatch(
-                p -> p.getMember().getId().equals(testMember.getId())
-        );
+                p -> p.getMember().getId().equals(testMember.getId()));
     }
 
     @Test
@@ -390,8 +397,8 @@ class ProductRepositoryTest {
                 List.of("image1.jpg"),
                 BigDecimal.valueOf(1500000),
                 Status.SELLING,
-                "main.jpg"
-        );
+                "main.jpg",
+                Condition.NEW);
 
         // when
         Product savedProduct = productRepository.save(product);
@@ -414,8 +421,8 @@ class ProductRepositoryTest {
                 List.of("image1.jpg", "image2.jpg", "image3.jpg"),
                 BigDecimal.valueOf(100000),
                 Status.SELLING,
-                "main.jpg"
-        );
+                "main.jpg",
+                Condition.NEW);
 
         // when
         Product savedProduct = productRepository.save(product);

--- a/src/test/java/potato/backend/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/potato/backend/domain/product/service/ProductServiceTest.java
@@ -12,10 +12,12 @@ import org.springframework.context.annotation.Import;
 
 import potato.backend.domain.category.domain.Category;
 import potato.backend.domain.category.repository.CategoryRepository;
+import potato.backend.domain.product.domain.Condition;
 import potato.backend.domain.product.domain.Product;
 import potato.backend.domain.product.domain.Status;
 import potato.backend.domain.product.dto.ProductCreateRequest;
 import potato.backend.domain.product.dto.ProductResponse;
+import potato.backend.domain.product.dto.ProductUpdateRequest;
 import potato.backend.domain.product.repository.ProductRepository;
 import potato.backend.domain.user.domain.Member;
 import potato.backend.domain.user.repository.MemberRepository;
@@ -25,53 +27,106 @@ import potato.backend.domain.user.repository.MemberRepository;
 @DisplayName("ProductService 상품 생성 테스트")
 class ProductServiceTest {
 
-    @Autowired
-    private ProductService productService;
+        @Autowired
+        private ProductService productService;
 
-    @Autowired
-    private ProductRepository productRepository;
+        @Autowired
+        private ProductRepository productRepository;
 
-    @Autowired
-    private MemberRepository memberRepository;
+        @Autowired
+        private MemberRepository memberRepository;
 
-    @Autowired
-    private CategoryRepository categoryRepository;
+        @Autowired
+        private CategoryRepository categoryRepository;
 
-    @Test
-    @DisplayName("회원, 이미지, 카테고리를 포함한 상품 생성 성공")
-    void createProduct_success() {
-        // given
-        Member seller = memberRepository.save(
-                Member.create("판매자", "seller@example.com", "hashed-password", "010-1111-2222")
-        );
+        @Test
+        @DisplayName("회원, 이미지, 카테고리를 포함한 상품 생성 성공")
+        void createProduct_success() {
+                // given
+                Member seller = memberRepository.save(
+                                Member.create("판매자", "seller@example.com", "hashed-password", "010-1111-2222"));
 
-        ProductCreateRequest request = ProductCreateRequest.of(
-                seller.getId(),
-                "테스트 상품",
-                List.of("디지털", "모바일"),
-                "테스트용 상품 설명",
-                "main-image.jpg",
-                List.of("detail1.jpg", "detail2.jpg"),
-                150_000L,
-                Status.SELLING.name()
-        );
+                ProductCreateRequest request = ProductCreateRequest.of(
+                                seller.getId(),
+                                "테스트 상품",
+                                List.of("디지털", "모바일"),
+                                "테스트용 상품 설명",
+                                "main-image.jpg",
+                                List.of("detail1.jpg", "detail2.jpg"),
+                                150_000L,
+                                Status.SELLING.name(),
+                                Condition.NEW.name());
 
-        // when
-        ProductResponse response = productService.createProduct(request);
+                // when
+                ProductResponse response = productService.createProduct(request);
 
-        // then
-        assertThat(response.getProductId()).isNotNull();
-        assertThat(response.getTitle()).isEqualTo("테스트 상품");
-        assertThat(response.getImages()).hasSize(2);
+                // then
+                assertThat(response.getProductId()).isNotNull();
+                assertThat(response.getTitle()).isEqualTo("테스트 상품");
+                assertThat(response.getImages()).hasSize(2);
 
-        Product persisted = productRepository.findById(response.getProductId()).orElseThrow();
-        assertThat(persisted.getMember().getId()).isEqualTo(seller.getId());
-        assertThat(persisted.getCategories()).hasSize(2);
-        assertThat(persisted.getCategories()).extracting(Category::getCategoryName)
-                .containsExactlyInAnyOrder("디지털", "모바일");
-        assertThat(persisted.getImages()).hasSize(2);
-        assertThat(persisted.getMainImageUrl()).isEqualTo("main-image.jpg");
-        assertThat(persisted.getStatus()).isEqualTo(Status.SELLING);
-        assertThat(categoryRepository.count()).isEqualTo(2);
-    }
+                Product persisted = productRepository.findById(response.getProductId()).orElseThrow();
+                assertThat(persisted.getMember().getId()).isEqualTo(seller.getId());
+                assertThat(persisted.getCategories()).hasSize(2);
+                assertThat(persisted.getCategories()).extracting(Category::getCategoryName)
+                                .containsExactlyInAnyOrder("디지털", "모바일");
+                assertThat(persisted.getImages()).hasSize(2);
+                assertThat(persisted.getMainImageUrl()).isEqualTo("main-image.jpg");
+                assertThat(persisted.getStatus()).isEqualTo(Status.SELLING);
+                assertThat(categoryRepository.count()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("상품 수정 성공 - 카테고리와 이미지 포함")
+        void updateProduct_success() {
+                // given
+                Member seller = memberRepository.save(
+                                Member.create("판매자", "seller@example.com", "hashed-password", "010-1111-2222"));
+
+                ProductCreateRequest createRequest = ProductCreateRequest.of(
+                                seller.getId(),
+                                "원래 상품",
+                                List.of("원래카테고리"),
+                                "원래 설명",
+                                "original-main.jpg",
+                                List.of("original-detail.jpg"),
+                                10000L,
+                                Status.SELLING.name(),
+                                "NEW");
+                ProductResponse createdProduct = productService.createProduct(createRequest);
+
+                ProductUpdateRequest updateRequest = ProductUpdateRequest.builder()
+                                .title("수정된 상품")
+                                .content("수정된 설명")
+                                .price(20000L)
+                                .status(Status.RESERVED.name())
+                                .mainImageUrl("updated-main.jpg")
+                                .imageUrls(List.of("updated-detail1.jpg", "updated-detail2.jpg"))
+                                .category(List.of("수정된카테고리1", "수정된카테고리2"))
+                                .build();
+
+                // when
+                ProductResponse updatedResponse = productService.updateProduct(createdProduct.getProductId(),
+                                updateRequest);
+
+                // then
+                assertThat(updatedResponse.getTitle()).isEqualTo("수정된 상품");
+
+                Product persisted = productRepository.findById(updatedResponse.getProductId()).orElseThrow();
+                assertThat(persisted.getTitle()).isEqualTo("수정된 상품");
+                assertThat(persisted.getContent()).isEqualTo("수정된 설명");
+                assertThat(persisted.getPrice()).isEqualByComparingTo(java.math.BigDecimal.valueOf(20000));
+                assertThat(persisted.getStatus()).isEqualTo(Status.RESERVED);
+                assertThat(persisted.getMainImageUrl()).isEqualTo("updated-main.jpg");
+
+                // 카테고리 검증
+                assertThat(persisted.getCategories()).hasSize(2);
+                assertThat(persisted.getCategories()).extracting(Category::getCategoryName)
+                                .containsExactlyInAnyOrder("수정된카테고리1", "수정된카테고리2");
+
+                // 이미지 검증
+                assertThat(persisted.getImages()).hasSize(2);
+                assertThat(persisted.getImages()).extracting(potato.backend.domain.image.domain.Image::getImageUrl)
+                                .containsExactlyInAnyOrder("updated-detail1.jpg", "updated-detail2.jpg");
+        }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ 작업한 브랜치

- feat/#66

👷 작업한 내용
- src/main/java/potato/backend/domain/product/domain/Product.java에 Condition 필드 및 열거형을 추가해 상품 상태를 DB에 저장하도록 확장
- ProductCreateRequest/ProductUpdateRequest DTO에 condition 필드를 추가하고 Swagger 스키마 정보를 갱신해 생성·수정 시 상태 전달 지원
- ProductResponse, ProductListResponse에 판매자 닉네임을 노출해 추가 조회 없이 사용자 정보를 확인 가능하도록 개선

🚨 참고 사항
- 없음

📟 관련 이슈
- Resolved: #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상품에 상태(NEW, USED, REFURBISHED) 정보 추가 및 생성/수정 요청에 상태 필드 도입
  * 상품 목록·상세 응답에 판매자 닉네임과 상품 상태 포함

* **기타**
  * 상품 수정 시 카테고리 및 이미지 교체 지원 추가
  * 상품 상태 표현 확장(RESERVED 상태 추가)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->