### PR TITLE
[Feat] 위시리스트 조회 api 구현 및 엔드포인트 임시 수정

### DIFF
--- a/src/main/java/potato/backend/domain/wishlist/controller/WishlistController.java
+++ b/src/main/java/potato/backend/domain/wishlist/controller/WishlistController.java
@@ -12,6 +12,9 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import potato.backend.domain.wishlist.service.WishlistService;
 import potato.backend.domain.wishlist.dto.WishlistResponse;
+import potato.backend.domain.wishlist.dto.WishlistListResponse;
+
+import java.util.List;
 
 @RestController
 @Validated
@@ -63,6 +66,21 @@ public class WishlistController {
         wishlistService.removeFromWishlist(memberId, productId);
         
         return ResponseEntity.noContent().build();
+    }
+
+    // 위시리스트 목록 조회
+    @Operation(summary = "위시리스트 목록 조회", description = "특정 회원의 위시리스트 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
+    })
+    @GetMapping("/members/{memberId}")
+    public ResponseEntity<List<WishlistListResponse>> getWishlistList(
+            @Parameter(description = "회원 ID", required = true)
+            @PathVariable Long memberId) {
+        
+        List<WishlistListResponse> wishlistList = wishlistService.getWishlistList(memberId);
+        return ResponseEntity.ok(wishlistList);
     }
 
     // 위시리스트 확인

--- a/src/main/java/potato/backend/domain/wishlist/controller/WishlistController.java
+++ b/src/main/java/potato/backend/domain/wishlist/controller/WishlistController.java
@@ -22,23 +22,19 @@ public class WishlistController {
 
     private final WishlistService wishlistService;
 
-    /**
-     * 위시리스트에 상품 추가
-     * @param memberId 회원 ID
-     * @param productId 상품 ID
-     */
+    // 위시리스트 추가
     @Operation(summary = "위시리스트 추가", description = "상품을 위시리스트에 추가합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "추가 성공"),
             @ApiResponse(responseCode = "404", description = "회원 또는 상품을 찾을 수 없음"),
             @ApiResponse(responseCode = "409", description = "이미 위시리스트에 추가된 상품")
     })
-    @PostMapping
+    @PostMapping("/members/{memberId}/products/{productId}")
     public ResponseEntity<WishlistResponse> addToWishlist(
-            @Parameter(description = "회원 ID")
-            @RequestParam Long memberId,
-            @Parameter(description = "상품 ID")
-            @RequestParam Long productId) {
+            @Parameter(description = "회원 ID", required = true)
+            @PathVariable Long memberId,
+            @Parameter(description = "상품 ID", required = true)
+            @PathVariable Long productId) {
         
         wishlistService.addToWishlist(memberId, productId);
         
@@ -51,42 +47,33 @@ public class WishlistController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    /**
-     * 위시리스트에서 상품 제거
-     * @param memberId 회원 ID
-     * @param productId 상품 ID
-     */
+    // 위시리스트 제거
     @Operation(summary = "위시리스트 제거", description = "상품을 위시리스트에서 제거합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "제거 성공"),
             @ApiResponse(responseCode = "404", description = "회원, 상품 또는 위시리스트를 찾을 수 없음")
     })
-    @DeleteMapping
+    @DeleteMapping("/members/{memberId}/products/{productId}")
     public ResponseEntity<Void> removeFromWishlist(
-            @Parameter(description = "회원 ID")
-            @RequestParam Long memberId,
-            @Parameter(description = "상품 ID")
-            @RequestParam Long productId) {
+            @Parameter(description = "회원 ID", required = true)
+            @PathVariable Long memberId,
+            @Parameter(description = "상품 ID", required = true)
+            @PathVariable Long productId) {
         
         wishlistService.removeFromWishlist(memberId, productId);
         
         return ResponseEntity.noContent().build();
     }
 
-    /**
-     * 위시리스트에 상품이 있는지 확인
-     * @param memberId 회원 ID
-     * @param productId 상품 ID
-     * @return true: 있음, false: 없음
-     */
+    // 위시리스트 확인
     @Operation(summary = "위시리스트 확인", description = "특정 상품이 위시리스트에 있는지 확인합니다.")
     @ApiResponse(responseCode = "200", description = "확인 성공")
-    @GetMapping("/check")
+    @GetMapping("/members/{memberId}/products/{productId}")
     public ResponseEntity<Boolean> isInWishlist(
-            @Parameter(description = "회원 ID")
-            @RequestParam Long memberId,
-            @Parameter(description = "상품 ID")
-            @RequestParam Long productId) {
+            @Parameter(description = "회원 ID", required = true)
+            @PathVariable Long memberId,
+            @Parameter(description = "상품 ID", required = true)
+            @PathVariable Long productId) {
         
         boolean isInWishlist = wishlistService.isInWishlist(memberId, productId);
         return ResponseEntity.ok(isInWishlist);

--- a/src/main/java/potato/backend/domain/wishlist/dto/WishlistListResponse.java
+++ b/src/main/java/potato/backend/domain/wishlist/dto/WishlistListResponse.java
@@ -1,0 +1,49 @@
+package potato.backend.domain.wishlist.dto;
+
+import lombok.Getter;
+import potato.backend.domain.category.domain.Category;
+import potato.backend.domain.product.domain.Product;
+import potato.backend.domain.wishlist.domain.Wishlist;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class WishlistListResponse {
+    private Long productId;
+    private Long sellerId;
+    private List<String> category;
+    private String title;
+    private Long price;
+    private String mainImageUrl;
+    private String status;
+    private Long likeCount;
+    private Long viewCount;
+    private Instant createdAt;
+    private Instant updatedAt;
+    private Instant wishlistCreatedAt; // 위시리스트에 추가된 시간
+
+    public static WishlistListResponse fromEntity(Wishlist wishlist) {
+        WishlistListResponse response = new WishlistListResponse();
+        Product product = wishlist.getProduct();
+        
+        response.productId = product.getId();
+        response.sellerId = product.getMember().getId();
+        response.category = product.getCategories()
+                .stream()
+                .map(Category::getCategoryName)
+                .collect(Collectors.toList());
+        response.title = product.getTitle();
+        response.price = product.getPrice().longValue();
+        response.mainImageUrl = product.getMainImageUrl();
+        response.status = product.getStatus().name();
+        response.likeCount = product.getLikeCount();
+        response.viewCount = product.getViewCount();
+        response.createdAt = product.getCreatedAt();
+        response.updatedAt = product.getUpdatedAt();
+        response.wishlistCreatedAt = wishlist.getCreatedAt();
+        
+        return response;
+    }
+}

--- a/src/main/java/potato/backend/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/potato/backend/domain/wishlist/repository/WishlistRepository.java
@@ -1,6 +1,8 @@
 package potato.backend.domain.wishlist.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import potato.backend.domain.wishlist.domain.Wishlist;
 import potato.backend.domain.user.domain.Member;
@@ -15,20 +17,19 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
     // 특정 회원의 위시리스트 목록 조회 (최신순)
     List<Wishlist> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 
-    /**
-     * 특정 회원과 상품으로 위시리스트 조회 (중복 체크용)
-     * @param member 회원
-     * @param product 상품
-     * @return 위시리스트 (있으면 존재, 없으면 empty)
-     */
+    // 특정 회원의 위시리스트 목록 조회
+    @Query("SELECT w FROM Wishlist w " +
+           "JOIN FETCH w.product p " +
+           "JOIN FETCH p.member " +
+           "LEFT JOIN FETCH p.categories " +
+           "WHERE w.member.id = :memberId " +
+           "ORDER BY w.createdAt DESC")
+    List<Wishlist> findByMemberIdWithDetails(@Param("memberId") Long memberId);
+
+    // 특정 회원과 상품으로 위시리스트 조회 (중복 체크용)
     Optional<Wishlist> findByMemberAndProduct(Member member, Product product);
 
-    /**
-     * 특정 회원과 상품으로 위시리스트 조회 (회원 ID, 상품 ID로)
-     * @param memberId 회원 ID
-     * @param productId 상품 ID
-     * @return 위시리스트 (있으면 존재, 없으면 empty)
-     */
+    // 특정 회원과 상품으로 위시리스트 조회 (회원 ID, 상품 ID로)
     Optional<Wishlist> findByMemberIdAndProductId(Long memberId, Long productId);
 
     // 특정 회원의 위시리스트 개수 조회

--- a/src/main/java/potato/backend/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/potato/backend/domain/wishlist/service/WishlistService.java
@@ -8,12 +8,14 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import potato.backend.domain.wishlist.domain.Wishlist;
 import potato.backend.domain.wishlist.repository.WishlistRepository;
+import potato.backend.domain.wishlist.dto.WishlistListResponse;
 import potato.backend.domain.user.domain.Member;
 import potato.backend.domain.user.repository.MemberRepository;
 import potato.backend.domain.product.domain.Product;
 import potato.backend.domain.product.repository.ProductRepository;
 
-import java.util.Optional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -65,6 +67,19 @@ public class WishlistService {
     @Transactional(readOnly = true)
     public boolean isInWishlist(Long memberId, Long productId) {
         return wishlistRepository.findByMemberIdAndProductId(memberId, productId).isPresent();
+    }
+
+    /**
+     * 회원의 위시리스트 목록 조회
+     * @param memberId 회원 ID
+     * @return 위시리스트 목록 (최신순)
+     */
+    public List<WishlistListResponse> getWishlistList(Long memberId) {
+        getMember(memberId); // 회원 존재 여부 확인
+        List<Wishlist> wishlists = wishlistRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+        return wishlists.stream()
+                .map(WishlistListResponse::fromEntity)
+                .collect(Collectors.toList());
     }
 
     // 회원의 위시리스트 개수 조회

--- a/src/main/java/potato/backend/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/potato/backend/domain/wishlist/service/WishlistService.java
@@ -76,7 +76,7 @@ public class WishlistService {
      */
     public List<WishlistListResponse> getWishlistList(Long memberId) {
         getMember(memberId); // 회원 존재 여부 확인
-        List<Wishlist> wishlists = wishlistRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+        List<Wishlist> wishlists = wishlistRepository.findByMemberIdWithDetails(memberId);
         return wishlists.stream()
                 .map(WishlistListResponse::fromEntity)
                 .collect(Collectors.toList());

--- a/src/main/java/potato/backend/global/config/FcmConfig.java
+++ b/src/main/java/potato/backend/global/config/FcmConfig.java
@@ -30,8 +30,26 @@ public class FcmConfig {
                     return;
                 }
 
+                // 환경 변수에서 가져온 값의 앞뒤 따옴표 제거
+                String jsonValue = serviceAccountJson.trim();
+                
+                // 앞뒤 따옴표 제거 (양쪽 모두 또는 한쪽만 있을 수 있음)
+                if (jsonValue.length() >= 2 && jsonValue.startsWith("\"") && jsonValue.endsWith("\"")) {
+                    jsonValue = jsonValue.substring(1, jsonValue.length() - 1);
+                } else if (jsonValue.length() >= 2 && jsonValue.startsWith("'") && jsonValue.endsWith("'")) {
+                    jsonValue = jsonValue.substring(1, jsonValue.length() - 1);
+                } else if (jsonValue.startsWith("\"")) {
+                    jsonValue = jsonValue.substring(1);
+                } else if (jsonValue.startsWith("'")) {
+                    jsonValue = jsonValue.substring(1);
+                } else if (jsonValue.endsWith("\"")) {
+                    jsonValue = jsonValue.substring(0, jsonValue.length() - 1);
+                } else if (jsonValue.endsWith("'")) {
+                    jsonValue = jsonValue.substring(0, jsonValue.length() - 1);
+                }
+
                 ByteArrayInputStream stream = new ByteArrayInputStream(
-                    serviceAccountJson.getBytes(StandardCharsets.UTF_8)
+                    jsonValue.getBytes(StandardCharsets.UTF_8)
                 );
                 
                 FirebaseOptions options = FirebaseOptions.builder()


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**

- feat/#65

👷 **작업한 내용**

위시리스트 조회 api 구현 및 엔드포인트 임시 변경했습니다. memberId를 파라미터로 받고 있지만 나중에 jwt토큰 잘 동작하면 수정 할 예정입니다.


<img width="778" height="835" alt="image" src="https://github.com/user-attachments/assets/c1935db5-9615-4248-bd21-e9f2238681ff" />


## 🚨 참고 사항

추가로 fcm json이 파싱 오류가 나서 코드 수정했습니다.

## 📟 관련 이슈

- Resolved: #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회원별 위시리스트 전체 조회 API 추가(최신 등록순), 위시리스트 목록 반환 개선

* **버그 수정**
  * Firebase 서비스 계정 설정 문자열의 따옴표 정규화 처리 개선

* **리팩토링**
  * 위시리스트 추가/삭제/포함 여부 확인 API를 쿼리 매개변수에서 경로 기반 엔드포인트로 전환하여 요청 형식 표준화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->