### PR TITLE
[Feat] 거래 체결 api와 판매내역 및 구매내역 조회 api 구현

### DIFF
--- a/src/main/java/potato/backend/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/potato/backend/domain/chat/domain/ChatRoom.java
@@ -6,6 +6,7 @@ import potato.backend.domain.common.domain.BaseEntity;
 import potato.backend.domain.product.domain.Product;
 import potato.backend.domain.user.domain.Member;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,6 +39,13 @@ public class ChatRoom extends BaseEntity {
     @Builder.Default
     private List<ChatMessage> messages = new ArrayList<>();
 
+    @Column(nullable = false, name = "is_completed")
+    @Builder.Default
+    private Boolean completed = false; // 거래 완료 여부
+
+    @Column(name = "completed_at")
+    private Instant completedAt; // 거래 완료 시각
+
 
     // ChatRoom 생성자
     public static ChatRoom create(Member seller, Member buyer, Product product) {
@@ -65,6 +73,15 @@ public class ChatRoom extends BaseEntity {
     // 채팅방 참여자 확인 메서드
     public boolean isParticipant(Member member) {
         return member != null && (member.equals(seller) || member.equals(buyer));
+    }
+
+    // 거래 완료 처리 메서드
+    public void completeTransaction() {
+        if (this.completed) {
+            throw new IllegalStateException("이미 거래가 완료된 채팅방입니다");
+        }
+        this.completed = true;
+        this.completedAt = Instant.now();
     }
 
 }

--- a/src/main/java/potato/backend/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/potato/backend/domain/chat/repository/ChatRoomRepository.java
@@ -44,7 +44,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     List<ChatRoom> findAllByMemberId(@Param("memberId") Long memberId);
 
     // 구매자가 거래 완료한 채팅방 목록을 조회하는 메서드
-    @Query("SELECT cr FROM ChatRoom cr " +
+    // DISTINCT 사용: @ManyToMany 관계인 categories 때문에 중복 제거 필요
+    @Query("SELECT DISTINCT cr FROM ChatRoom cr " +
            "JOIN FETCH cr.product p " +
            "JOIN FETCH p.member " +
            "LEFT JOIN FETCH p.categories " +

--- a/src/main/java/potato/backend/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/potato/backend/domain/chat/repository/ChatRoomRepository.java
@@ -42,4 +42,13 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
      */
     @Query("select cr from ChatRoom cr where cr.seller.id = :memberId or cr.buyer.id = :memberId")
     List<ChatRoom> findAllByMemberId(@Param("memberId") Long memberId);
+
+    // 구매자가 거래 완료한 채팅방 목록을 조회하는 메서드
+    @Query("SELECT cr FROM ChatRoom cr " +
+           "JOIN FETCH cr.product p " +
+           "JOIN FETCH p.member " +
+           "LEFT JOIN FETCH p.categories " +
+           "WHERE cr.buyer.id = :buyerId AND cr.completed = true " +
+           "ORDER BY cr.completedAt DESC")
+    List<ChatRoom> findCompletedByBuyerIdWithProduct(@Param("buyerId") Long buyerId);
 }

--- a/src/main/java/potato/backend/domain/product/domain/Product.java
+++ b/src/main/java/potato/backend/domain/product/domain/Product.java
@@ -34,6 +34,10 @@ public class Product extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false) // DB의 product 테이블에 생성될 외래 키 컬럼 이름을 'member_id'로 지정
     private Member member;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "buyer_id")
+    private Member buyer; // 실제 구매자 (거래 완료 시 저장, nullable)
+
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "product_categories",
             joinColumns = @JoinColumn(name = "product_id"),
@@ -190,6 +194,18 @@ public class Product extends BaseEntity {
                     .toList();
             this.images.addAll(newImages);
         }
+    }
+
+    // 거래 완료 처리 메서드 (구매자 설정 및 상태 변경)
+    public void markAsSoldOut(Member buyer) {
+        if (this.status == Status.SOLD_OUT) {
+            throw new IllegalStateException("이미 판매 완료된 상품입니다");
+        }
+        if (buyer == null) {
+            throw new IllegalArgumentException("구매자는 null일 수 없습니다");
+        }
+        this.buyer = buyer;
+        this.status = Status.SOLD_OUT;
     }
 
 }

--- a/src/main/java/potato/backend/domain/product/repository/ProductRepository.java
+++ b/src/main/java/potato/backend/domain/product/repository/ProductRepository.java
@@ -52,11 +52,34 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     long countAllProducts();
     
     /**
-     * 사용자별 상품 조회 (사용자아이디)
+     * 사용자별 상품 조회 (사용자아이디) - 페이징 포함
      * SQL: SELECT * FROM product WHERE 사용자아이디 = ? ORDER BY created_at DESC
      */
     @Query("SELECT p FROM Product p WHERE p.member.id = :memberId ORDER BY p.createdAt DESC")
     Page<Product> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+    /**
+     * 사용자별 상품 조회 (사용자아이디) - 리스트 반환 (판매내역 조회용)
+     * SQL: SELECT * FROM product WHERE 사용자아이디 = ? ORDER BY created_at DESC
+     */
+    @Query("SELECT p FROM Product p " +
+           "JOIN FETCH p.member " +
+           "LEFT JOIN FETCH p.categories " +
+           "WHERE p.member.id = :memberId " +
+           "ORDER BY p.createdAt DESC")
+    java.util.List<Product> findByMemberIdWithDetails(@Param("memberId") Long memberId);
+
+    /**
+     * 구매자별 상품 조회 (구매내역 조회용)
+     * SQL: SELECT * FROM product WHERE buyer_id = ? ORDER BY created_at DESC
+     */
+    @Query("SELECT p FROM Product p " +
+           "JOIN FETCH p.member " +
+           "JOIN FETCH p.buyer " +
+           "LEFT JOIN FETCH p.categories " +
+           "WHERE p.buyer.id = :buyerId " +
+           "ORDER BY p.createdAt DESC")
+    java.util.List<Product> findByBuyerIdWithDetails(@Param("buyerId") Long buyerId);
     
     /**
      * 상태별 상품 조회 (상태)

--- a/src/main/java/potato/backend/domain/product/repository/ProductRepository.java
+++ b/src/main/java/potato/backend/domain/product/repository/ProductRepository.java
@@ -61,8 +61,9 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     /**
      * 사용자별 상품 조회 (사용자아이디) - 리스트 반환 (판매내역 조회용)
      * SQL: SELECT * FROM product WHERE 사용자아이디 = ? ORDER BY created_at DESC
+     * DISTINCT 사용: @ManyToMany 관계인 categories 때문에 중복 제거 필요
      */
-    @Query("SELECT p FROM Product p " +
+    @Query("SELECT DISTINCT p FROM Product p " +
            "JOIN FETCH p.member " +
            "LEFT JOIN FETCH p.categories " +
            "WHERE p.member.id = :memberId " +
@@ -72,8 +73,9 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     /**
      * 구매자별 상품 조회 (구매내역 조회용)
      * SQL: SELECT * FROM product WHERE buyer_id = ? ORDER BY created_at DESC
+     * DISTINCT 사용: @ManyToMany 관계인 categories 때문에 중복 제거 필요
      */
-    @Query("SELECT p FROM Product p " +
+    @Query("SELECT DISTINCT p FROM Product p " +
            "JOIN FETCH p.member " +
            "JOIN FETCH p.buyer " +
            "LEFT JOIN FETCH p.categories " +

--- a/src/main/java/potato/backend/domain/user/controller/MemberController.java
+++ b/src/main/java/potato/backend/domain/user/controller/MemberController.java
@@ -1,6 +1,7 @@
 package potato.backend.domain.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -11,12 +12,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import potato.backend.domain.product.dto.ProductListResponse;
 import potato.backend.domain.user.dto.FcmTokenRequest;
 import potato.backend.domain.user.dto.FcmTokenResponse;
 import potato.backend.domain.user.dto.SignUpRequest;
 import potato.backend.domain.user.dto.SignUpResponse;
 import potato.backend.domain.user.service.MemberService;
 import potato.backend.global.util.MemberUtil;
+
+import java.util.List;
 
 /**
  * 회원 관련 컨트롤러
@@ -97,6 +101,96 @@ public class MemberController {
         log.info("FCM 토큰 등록 완료: memberId={}", authenticatedMemberId);
         
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 마이페이지 - 판매내역 조회 API
+     * 내가 등록한 상품 목록을 조회합니다.
+     */
+    @Operation(summary = "판매내역 조회", description = "내가 등록한 상품 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "판매내역 조회 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductListResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
+    @GetMapping("/me/sales")
+    public ResponseEntity<List<ProductListResponse>> getSalesHistory() {
+        Long authenticatedMemberId = memberUtil.getCurrentUser().memberId();
+        log.info("판매내역 조회 요청: memberId={}", authenticatedMemberId);
+
+        List<ProductListResponse> salesHistory = memberService.getSalesHistory(authenticatedMemberId);
+        log.info("판매내역 조회 완료: memberId={}, 상품 개수={}", authenticatedMemberId, salesHistory.size());
+
+        return ResponseEntity.ok(salesHistory);
+    }
+
+    /**
+     * 마이페이지 - 구매내역 조회 API
+     * 내가 구매한 상품 목록을 조회합니다.
+     */
+    @Operation(summary = "구매내역 조회", description = "내가 구매한 상품 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "구매내역 조회 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductListResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
+    @GetMapping("/me/purchases")
+    public ResponseEntity<List<ProductListResponse>> getPurchaseHistory() {
+        Long authenticatedMemberId = memberUtil.getCurrentUser().memberId();
+        log.info("구매내역 조회 요청: memberId={}", authenticatedMemberId);
+
+        List<ProductListResponse> purchaseHistory = memberService.getPurchaseHistory(authenticatedMemberId);
+        log.info("구매내역 조회 완료: memberId={}, 상품 개수={}", authenticatedMemberId, purchaseHistory.size());
+
+        return ResponseEntity.ok(purchaseHistory);
+    }
+
+    /**
+     * 테스트용 - 판매내역 조회 API (memberId 파라미터로 받기)
+     * 개발 환경에서만 사용하세요.
+     */
+    @Operation(summary = "판매내역 조회 (테스트용)", description = "memberId를 파라미터로 받아 판매내역을 조회합니다. 개발/테스트 전용입니다.")
+    @GetMapping("/{memberId}/sales")
+    public ResponseEntity<List<ProductListResponse>> getSalesHistoryForTest(
+            @Parameter(description = "회원 ID", required = true)
+            @PathVariable Long memberId) {
+        log.info("판매내역 조회 요청 (테스트용): memberId={}", memberId);
+
+        List<ProductListResponse> salesHistory = memberService.getSalesHistory(memberId);
+        log.info("판매내역 조회 완료 (테스트용): memberId={}, 상품 개수={}", memberId, salesHistory.size());
+
+        return ResponseEntity.ok(salesHistory);
+    }
+
+    /**
+     * 테스트용 - 구매내역 조회 API (memberId 파라미터로 받기)
+     * 개발 환경에서만 사용하세요.
+     */
+    @Operation(summary = "구매내역 조회 (테스트용)", description = "memberId를 파라미터로 받아 구매내역을 조회합니다. 개발/테스트 전용입니다.")
+    @GetMapping("/{memberId}/purchases")
+    public ResponseEntity<List<ProductListResponse>> getPurchaseHistoryForTest(
+            @Parameter(description = "회원 ID", required = true)
+            @PathVariable Long memberId) {
+        log.info("구매내역 조회 요청 (테스트용): memberId={}", memberId);
+
+        List<ProductListResponse> purchaseHistory = memberService.getPurchaseHistory(memberId);
+        log.info("구매내역 조회 완료 (테스트용): memberId={}, 상품 개수={}", memberId, purchaseHistory.size());
+
+        return ResponseEntity.ok(purchaseHistory);
     }
 }
 

--- a/src/main/java/potato/backend/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/potato/backend/domain/wishlist/repository/WishlistRepository.java
@@ -18,7 +18,8 @@ public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
     List<Wishlist> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 
     // 특정 회원의 위시리스트 목록 조회
-    @Query("SELECT w FROM Wishlist w " +
+    // DISTINCT 사용: @ManyToMany 관계인 categories 때문에 중복 제거 필요
+    @Query("SELECT DISTINCT w FROM Wishlist w " +
            "JOIN FETCH w.product p " +
            "JOIN FETCH p.member " +
            "LEFT JOIN FETCH p.categories " +

--- a/src/main/java/potato/backend/global/config/SecurityConfig.java
+++ b/src/main/java/potato/backend/global/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
                                 "/api/v1/chat/**",  // 채팅 API 임시 허용
                                 "/api/v1/images/**",  // 이미지 업로드 API 허용
                                 "/api/v1/products/**",  // 상품 API 허용
+                                "/api/v1/members/**",  // 회원 API 테스트용 임시 허용 (개발 전용)
                                 "/websocket-test.html",  // WebSocket 테스트 페이지 허용
                                 "/fcm-token-test.html",  // FCM 토큰 테스트 페이지 허용
                                 "/firebase-messaging-sw.js",  // FCM 테스트용 서비스 워커 허용


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**

- feature/#70

👷 **작업한 내용**

### 거래 체결 api
타 중고거래 사이트와 비슷하게 판매자가 거래체결을 누르면 거래가 완료되도록 구현했습니다.
판매자 - 구매자 채팅방에서 판매자가 거래완료를 누를 수 있습니다.
(Product에 Buyer추가, ChatRoom에 거래 완료 여부 추가)

### 판매내역 및 구매내역 조회 api
마이페이지에서 사용할 api입니다.
판매내역 api
<img width="667" height="865" alt="image" src="https://github.com/user-attachments/assets/b2281b72-41f5-4991-9984-3657ed190694" />
구매내역 api
<img width="601" height="796" alt="image" src="https://github.com/user-attachments/assets/ce9f1247-626d-4cb1-9ca0-4f45c1c0d450" />


## 🚨 참고 사항

구현한 api는 memberId를 파라미터로 받도록 테스트하였습니다. 후에 jwt가 되면 수정해야합니다.

## 📟 관련 이슈

- Resolved: #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅방에서 거래 완료 처리 기능 추가
  * 사용자의 판매 이력 및 구매 이력 조회 기능 추가
  * 상품에 구매자 정보 등록 및 판매 완료 상태 관리 추가

* **테스트**
  * 거래 완료용 테스트 API 엔드포인트 추가
  * 이력 조회용 테스트 API 엔드포인트 추가

* **기타**
  * 일부 조회 쿼리에서 중복 제거 및 정렬 개선
  * 일부 API 경로의 보안 허용 범위 일시 완화 (개발/테스트용)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->