### PR TITLE
Feat: 일반 로그인 구현

### DIFF
--- a/src/main/java/potato/backend/domain/user/repository/MemberRepository.java
+++ b/src/main/java/potato/backend/domain/user/repository/MemberRepository.java
@@ -10,4 +10,5 @@ import potato.backend.domain.user.domain.Member;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByOauthId(String oauthId);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/potato/backend/global/config/SecurityConfig.java
+++ b/src/main/java/potato/backend/global/config/SecurityConfig.java
@@ -11,6 +11,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -51,6 +53,10 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/v3/api-docs.yaml",
                                 "/auth/**",
+                                "/api/v1/login",
+                                "/api/v1/logout",
+                                "/api/v1/auth/providers",
+                                "/api/v1/auth/token/issue",
                                 "/oauth2/**",
                                 "/login/oauth2/**",
                                 "/h2-console/**",
@@ -108,5 +114,10 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/potato/backend/global/constant/SecurityConstant.java
+++ b/src/main/java/potato/backend/global/constant/SecurityConstant.java
@@ -3,6 +3,7 @@ package potato.backend.global.constant;
 public class SecurityConstant {
 
     // JWT
+    public static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
     public static final String REFRESH_TOKEN_COOKIE_NAME = "RTOKEN";
     public static final long ACCESS_TOKEN_EXPIRATION_SECONDS = 60 * 30;
     public static final long REFRESH_TOKEN_EXPIRATION_SECONDS = 60 * 60 * 24 * 14;

--- a/src/main/java/potato/backend/global/exception/ErrorCode.java
+++ b/src/main/java/potato/backend/global/exception/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
 
     // 회원
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다"),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다"),
+    INVALID_LOGIN_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다"),
 
     // 커리큘럼
     CURRICULUM_NOT_FOUND(HttpStatus.NOT_FOUND, "커리큘럼을 찾을 수 없습니다"),

--- a/src/main/java/potato/backend/global/security/controller/LoginController.java
+++ b/src/main/java/potato/backend/global/security/controller/LoginController.java
@@ -1,0 +1,144 @@
+package potato.backend.global.security.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.jsonwebtoken.Claims;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import potato.backend.domain.user.domain.Member;
+import potato.backend.domain.user.repository.MemberRepository;
+import potato.backend.global.exception.CustomException;
+import potato.backend.global.exception.ErrorCode;
+import potato.backend.global.security.dto.LoginRequest;
+import potato.backend.global.security.dto.LoginResponse;
+import potato.backend.global.security.jwt.JwtService;
+import potato.backend.global.security.jwt.JwtUtil;
+import potato.backend.global.security.jwt.RefreshTokenRepository;
+import potato.backend.global.security.oauth.UserInfo;
+import potato.backend.global.util.CookieUtil;
+import potato.backend.global.util.UrlUtil;
+
+import org.springframework.boot.web.server.Cookie.SameSite;
+
+import static potato.backend.global.constant.SecurityConstant.REFRESH_TOKEN_COOKIE_NAME;
+import static potato.backend.global.constant.SecurityConstant.REFRESH_TOKEN_EXPIRATION_SECONDS;
+
+@Tag(name = "login")
+@Slf4j
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class LoginController {
+
+    private final JwtService jwtService;
+    private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @PostMapping("/login")
+    @Operation(
+            summary = "일반 로그인",
+            description = "이메일과 비밀번호를 사용하여 로그인합니다.",
+            responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = LoginResponse.class))),
+                @ApiResponse(responseCode = "401", description = "이메일 또는 비밀번호가 올바르지 않습니다", content = @Content),
+            })
+    public ResponseEntity<LoginResponse> login(
+            @Valid @RequestBody LoginRequest loginRequest,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        // 1. 이메일로 회원 조회
+        Member member = memberRepository.findByEmail(loginRequest.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_LOGIN_CREDENTIALS));
+
+        // 2. 비밀번호가 없는 경우 (OAuth 회원)
+        if (member.getHashedPassword() == null || member.getHashedPassword().isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_LOGIN_CREDENTIALS);
+        }
+
+        // 3. 비밀번호 검증
+        if (!passwordEncoder.matches(loginRequest.getPassword(), member.getHashedPassword())) {
+            throw new CustomException(ErrorCode.INVALID_LOGIN_CREDENTIALS);
+        }
+
+        // 4. UserInfo 객체 생성
+        UserInfo userInfo = UserInfo.from(member);
+
+        // 5. JWT 토큰 생성
+        String accessToken = jwtService.createAccessToken(userInfo);
+        String refreshToken = jwtService.createRefreshToken(userInfo);
+
+        // 6. Refresh Token을 쿠키에 저장
+        CookieUtil.addCookie(
+                response,
+                REFRESH_TOKEN_COOKIE_NAME,
+                refreshToken,
+                "/api/v1/auth",
+                SameSite.NONE,
+                UrlUtil.getRegistrableDomain(request.getServerName()),
+                REFRESH_TOKEN_EXPIRATION_SECONDS);
+
+        // 7. 응답 반환
+        LoginResponse loginResponse = new LoginResponse(
+                accessToken,
+                member.getId(),
+                member.getName(),
+                member.getEmail());
+
+        return ResponseEntity.ok(loginResponse);
+    }
+
+    @PostMapping("/logout")
+    @Operation(
+            summary = "로그아웃",
+            description = "Refresh Token을 삭제하고 로그아웃합니다. (일반 로그인 및 소셜 로그인 공통)",
+            responses = {@ApiResponse(responseCode = "200", description = "로그아웃 성공")})
+    public ResponseEntity<Void> logout(
+            @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshTokenCookie,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        if (refreshTokenCookie != null && !refreshTokenCookie.isEmpty()) {
+            Claims claims;
+            try {
+                claims = jwtUtil.getClaims(refreshTokenCookie);
+                Long memberId = Long.parseLong(claims.getSubject());
+                refreshTokenRepository.deleteById(memberId);
+            } catch (Exception ignored) {
+            }
+        }
+
+        // 리프레시 토큰 쿠키 삭제
+        CookieUtil.deleteCookie(request, response, REFRESH_TOKEN_COOKIE_NAME, "/api/v1/auth");
+
+        // 스프링 시큐리티 컨텍스트 초기화
+        SecurityContextHolder.clearContext();
+
+        return ResponseEntity.ok().build();
+    }
+}
+

--- a/src/main/java/potato/backend/global/security/dto/LoginRequest.java
+++ b/src/main/java/potato/backend/global/security/dto/LoginRequest.java
@@ -1,0 +1,20 @@
+package potato.backend.global.security.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "유효한 이메일 형식이 아닙니다")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    private String password;
+}
+

--- a/src/main/java/potato/backend/global/security/dto/LoginResponse.java
+++ b/src/main/java/potato/backend/global/security/dto/LoginResponse.java
@@ -1,0 +1,14 @@
+package potato.backend.global.security.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+    private String accessToken;
+    private Long memberId;
+    private String name;
+    private String email;
+}
+

--- a/src/main/java/potato/backend/global/security/dto/LoginResponse.java
+++ b/src/main/java/potato/backend/global/security/dto/LoginResponse.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class LoginResponse {
-    private String accessToken;
     private Long memberId;
     private String name;
     private String email;

--- a/src/main/java/potato/backend/global/security/filter/JwtFilter.java
+++ b/src/main/java/potato/backend/global/security/filter/JwtFilter.java
@@ -15,6 +15,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import potato.backend.global.security.jwt.JwtUtil;
 
+import static potato.backend.global.constant.SecurityConstant.ACCESS_TOKEN_COOKIE_NAME;
+
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
@@ -67,8 +69,7 @@ public class JwtFilter extends OncePerRequestFilter {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
-                // SuccessHandler에서 설정한 쿠키 이름과 같은 경우 토큰 추출
-                if ("accessToken".equals(cookie.getName())) {
+                if (ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
                     return cookie.getValue();
                 }
             }

--- a/src/main/java/potato/backend/global/security/oauth/CustomSuccessHandler.java
+++ b/src/main/java/potato/backend/global/security/oauth/CustomSuccessHandler.java
@@ -30,8 +30,6 @@ import static potato.backend.global.constant.UrlConstant.DEFAULT_CLIENT_URL;
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtService jwtService;
-    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
-    private static final long ACCESS_TOKEN_EXPIRATION_SECONDS = 60 * 30;
 
     @Override
     public void onAuthenticationSuccess(


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**

- feature/#이슈번호

### feat: 일반 로그인 기능 구현
- LoginController, LoginRequest, LoginResponse 추가
- MemberRepository에 findByEmail 추가
- 에러 코드 추가
### feat: 소셜 로그인 성공 후 Access Token 전달 개선
- CustomSuccessHandler에서 Access Token을 쿼리 파라미터로 전달
### feat: 소셜 로그인 제공자 목록 조회 API 추가
- AuthController에 /api/v1/auth/providers 엔드포인트 추가
### config: 인증 관련 엔드포인트 SecurityConfig에 허용
- SecurityConfig에 인증 관련 경로 허용 추가

<!-- 작업한 내용을 적어주세요. -->

## 🚨 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈

- Resolved: #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이메일/비밀번호 표준 로그인·로그아웃 엔드포인트 추가 및 로그인 시 사용자 정보 응답 제공(토큰은 쿠키로 발급)
  * 사용 가능한 OAuth 제공자 목록을 반환하는 제공자 검색 엔드포인트 추가
  * OAuth 로그인 성공 시 엑세스·리프레시 토큰을 각각 쿠키에 저장

* **보안 개선**
  * 로그인 관련 엔드포인트를 허용하고 BCrypt 기반 비밀번호 인코더 도입
  * 인증 미들웨어가 헤더 토큰 없을 때 쿠키의 엑세스 토큰을 대체로 확인하도록 확장

* **버그 수정**
  * 비밀번호·로그인 자격증명 오류에 대한 상세한 오류 코드/메시지 추가
* **기타**
  * 이메일로 사용자 조회 기능 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->