### PR TITLE
feat: 회원가입 API 구현 및 비밀번호 길이 제한 처리

### DIFF
--- a/src/main/java/potato/backend/domain/user/dto/SignUpRequest.java
+++ b/src/main/java/potato/backend/domain/user/dto/SignUpRequest.java
@@ -3,7 +3,6 @@ package potato.backend.domain.user.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 /**
@@ -20,7 +19,6 @@ public class SignUpRequest {
     private String email;
 
     @NotBlank(message = "비밀번호는 필수입니다")
-    @Size(max = 72, message = "비밀번호는 최대 72바이트까지 가능합니다")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$", 
              message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다")
     private String password;

--- a/src/main/java/potato/backend/domain/user/dto/SignUpRequest.java
+++ b/src/main/java/potato/backend/domain/user/dto/SignUpRequest.java
@@ -3,6 +3,7 @@ package potato.backend.domain.user.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 /**
@@ -19,6 +20,7 @@ public class SignUpRequest {
     private String email;
 
     @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(max = 72, message = "비밀번호는 최대 72바이트까지 가능합니다")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$", 
              message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다")
     private String password;

--- a/src/main/java/potato/backend/domain/user/service/MemberService.java
+++ b/src/main/java/potato/backend/domain/user/service/MemberService.java
@@ -66,8 +66,28 @@ public class MemberService {
             throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
 
+        // 비밀번호 길이 체크 (BCrypt는 72바이트 제한)
+        byte[] passwordBytes = request.getPassword().getBytes();
+        if (passwordBytes.length > 72) {
+            log.warn("비밀번호 길이 초과: {} bytes (최대 72바이트)", passwordBytes.length);
+            throw new CustomException(ErrorCode.PASSWORD_TOO_LONG);
+        }
+
         // 비밀번호 암호화
-        String hashedPassword = passwordEncoder.encode(request.getPassword());
+        String hashedPassword;
+        try {
+            hashedPassword = passwordEncoder.encode(request.getPassword());
+        } catch (IllegalArgumentException e) {
+            // BCryptPasswordEncoder가 72바이트 초과 시 IllegalArgumentException 발생
+            String errorMessage = e.getMessage();
+            if (errorMessage != null && (errorMessage.contains("72") || errorMessage.contains("cannot be more than"))) {
+                log.warn("BCryptPasswordEncoder 비밀번호 길이 초과: {}", errorMessage);
+                throw new CustomException(ErrorCode.PASSWORD_TOO_LONG);
+            }
+            // 다른 IllegalArgumentException은 그대로 전파
+            log.error("비밀번호 암호화 중 예외 발생: {}", errorMessage, e);
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT, "비밀번호 암호화에 실패했습니다: " + errorMessage);
+        }
 
         // 회원 생성
         Member member = Member.create(

--- a/src/main/java/potato/backend/global/exception/ErrorCode.java
+++ b/src/main/java/potato/backend/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다"),
     INVALID_LOGIN_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다"),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다"),
+    PASSWORD_TOO_LONG(HttpStatus.BAD_REQUEST, "비밀번호는 최대 72바이트까지 가능합니다"),
 
     // 커리큘럼
     CURRICULUM_NOT_FOUND(HttpStatus.NOT_FOUND, "커리큘럼을 찾을 수 없습니다"),

--- a/src/main/java/potato/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/potato/backend/global/exception/GlobalExceptionHandler.java
@@ -206,14 +206,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
         logByType(e);
-        
-        // BCryptPasswordEncoder의 비밀번호 길이 초과 예외 처리
-        String errorMessage = e.getMessage();
-        if (errorMessage != null && (errorMessage.contains("72") || errorMessage.contains("cannot be more than"))) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(ErrorResponse.of(ErrorCode.PASSWORD_TOO_LONG));
-        }
-        
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(ErrorCode.INVALID_ARGUMENT, e.getMessage()));
     }

--- a/src/main/java/potato/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/potato/backend/global/exception/GlobalExceptionHandler.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
-import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import lombok.extern.slf4j.Slf4j;
@@ -207,6 +206,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
         logByType(e);
+        
+        // BCryptPasswordEncoder의 비밀번호 길이 초과 예외 처리
+        String errorMessage = e.getMessage();
+        if (errorMessage != null && (errorMessage.contains("72") || errorMessage.contains("cannot be more than"))) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ErrorResponse.of(ErrorCode.PASSWORD_TOO_LONG));
+        }
+        
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(ErrorCode.INVALID_ARGUMENT, e.getMessage()));
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,7 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "https://api.8aladin.shop/login/oauth2/code/google"
             scope:
               - profile
               - email
@@ -46,7 +47,7 @@ spring:
             client-secret: ${NAVER_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "https://api.8aladin.shop/login/oauth2/code/naver"
             scope:
               - name
               - email
@@ -56,7 +57,7 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "https://api.8aladin.shop/login/oauth2/code/kakao"
             scope:
               - profile_nickname
               - account_email
@@ -69,7 +70,7 @@ spring:
             user-name-attribute: response
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kapi.kakao.com/oauth/token
+            token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 


### PR DESCRIPTION
비밀번호 BCrypt 72바이트 제한 검증
이메일 중복 체크
적절한 에러 코드 및 예외 처리

## 🔥*Pull requests*

⛳️ **작업한 브랜치**

- feature/#이슈번호

👷 **작업한 내용**

<!-- 작업한 내용을 적어주세요. -->

## 🚨 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

## 📟 관련 이슈

- Resolved: #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 회원가입 시 비밀번호 길이(최대 72바이트) 검증을 추가했습니다. 초과 시 명확한 오류(PASSWORD_TOO_LONG)가 반환됩니다.
* **설정 변경**
  * OAuth2 리디렉션 URI를 고정된 엔드포인트로 명시적으로 설정했습니다(그룹별 제공자별 URL 업데이트).
  * 카카오 토큰 엔드포인트 주소를 최신 값으로 변경했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->